### PR TITLE
Correctly scale temperatures

### DIFF
--- a/cyp/data/preprocessing.py
+++ b/cyp/data/preprocessing.py
@@ -193,6 +193,12 @@ def process_county(
         axes=(1, 2, 0),
     )
 
+    # From https://developers.google.com/earth-engine/datasets/catalog/MODIS_006_MOD09A1#description,
+    # the temperature bands are in Kelvin, with a scale of 0.02. 11500 therefore represents -43C,
+    # and (with a bin range of 4999), we get to 16500 which represents 57C - this should
+    # comfortably cover the range of expected temperatures for these counties.
+    temp -= 11500
+
     mask = np.transpose(
         np.array(gdal.Open(str(mask_path)).ReadAsArray(), dtype="uint16"),
         axes=(1, 2, 0),


### PR DESCRIPTION
The scale for the MODIS temperature datasets is Kelvin * 0.02.

This means that if we calculate histograms on a range `[0, 4999]`, we are considering temperatures from 0 Kelvin to ~-173 Kelvin.

This PR scales the temperature so that instead, temperatures from roughly -43 C to 57 C are covered.